### PR TITLE
Customization and first steps towards packaging IBM's TPM 2.0 tools

### DIFF
--- a/utils/makefile
+++ b/utils/makefile
@@ -200,7 +200,7 @@ PREFIX = /opt/tpm
 
 .PHONY: install
 install: $(ALL)
-		install -d $(DESTDIR)/$(PREFIX)/bin
+		install -d $(DESTDIR)$(PREFIX)/bin
 		for f in $(ALL); do \
 			install -D -T $$f $(DESTDIR)/$(PREFIX)/bin/ibm_tpm2_$$f; \
 		done

--- a/utils/makefile
+++ b/utils/makefile
@@ -95,7 +95,7 @@ LNLLIBS += -lcrypto
 # link - for applications, TSS path, TSS and OpenSSl libraries
 
 # hardening flags for linking executables
-LNAFLAGS += -pie -Wl,-z,now -Wl,-rpath,.
+LNAFLAGS += -pie -Wl,-z,now -Wl,-rpath='$$ORIGIN'
 
 LNALIBS +=  -ltss -lcrypto
 

--- a/utils/makefile
+++ b/utils/makefile
@@ -44,7 +44,7 @@ CC = /usr/bin/gcc
 
 # compile - common flags for TSS library and applications
 
-CCFLAGS += 	-DTPM_POSIX -DTPM_INTERFACE_TYPE_DEFAULT="\"dev\""
+CCFLAGS += 	-DTPM_POSIX -DTPM_INTERFACE_TYPE_DEFAULT="\"dev\"" -DTPM_ENCRYPT_SESSIONS_DEFAULT="\"0\""
 
 # example of pointing to a locally built openssl 1.1
 # CCFLAGS += 	-I/home/kgold/openssl-1.1.0c/include

--- a/utils/makefile
+++ b/utils/makefile
@@ -196,6 +196,19 @@ $(LIBTSS): 	$(TSS_OBJS)
 .PHONY:		clean
 .PRECIOUS:	%.o
 
+PREFIX = /opt/tpm
+
+.PHONY: install
+install: $(ALL)
+		install -d $(DESTDIR)/$(PREFIX)/bin
+		for f in $(ALL); do \
+			install -D -T $$f $(DESTDIR)/$(PREFIX)/bin/ibm_tpm2_$$f; \
+		done
+
+.PHONY: uninstall
+uninstall:
+		rm -r $(DESTDIR)$(PREFIX)/bin
+
 clean:
 		rm -f *.o  *~ 	\
 		h*.bin		\

--- a/utils/makefile
+++ b/utils/makefile
@@ -201,13 +201,16 @@ PREFIX = /opt/tpm
 .PHONY: install
 install: $(ALL)
 		install -d $(DESTDIR)$(PREFIX)/bin
-		for f in $(ALL); do \
+		for f in $(UTILS); do \
 			install -D -T $$f $(DESTDIR)/$(PREFIX)/bin/ibm_tpm2_$$f; \
 		done
+		install -D -t $(DESTDIR)$(PREFIX)/bin $(LIBTSSSONAME)
+		install -D -t $(DESTDIR)$(PREFIX)/bin $(LIBTSSVERSIONED)
+		ln -srf $(DESTDIR)$(PREFIX)/bin/$(LIBTSSSONAME) $(DESTDIR)$(PREFIX)/bin/$(LIBTSS)
 
 .PHONY: uninstall
 uninstall:
-		rm -r $(DESTDIR)$(PREFIX)/bin
+		rm -rf $(DESTDIR)$(PREFIX)/bin
 
 clean:
 		rm -f *.o  *~ 	\

--- a/utils/makefile-common
+++ b/utils/makefile-common
@@ -57,9 +57,11 @@ CCFLAGS += -DTPM_NUVOTON
 
 #LNFLAGS += 	-ggdb
 
+LIBS += \
+	$(LIBTSS) \
+	$(LIBTSSA)
 
-ALL += 	$(LIBTSS)				\
-	$(LIBTSSA)				\
+UTILS += \
 	activatecredential$(EXE)		\
 	eventextend$(EXE)			\
 	imaextend$(EXE)				\
@@ -165,12 +167,14 @@ ALL += 	$(LIBTSS)				\
 	timepacket$(EXE)			\
 	createek$(EXE)
 
-ALL	+= 					\
+UTILS	+= 					\
 	ntc2getconfig$(EXE)			\
 	ntc2preconfig$(EXE)			\
 	ntc2lockconfig$(EXE)
 
-# TSS shared library headers 
+ALL += $(LIBS) $(UTILS)
+
+# TSS shared library headers
 
 TSS_HEADERS += 					\
 		tssauth.h 			\


### PR DESCRIPTION
### Notes
* Session state encryption should eventually be turned back ON :warning: See `ibmtss.doc` section 4.9
* Linking `ALL` targets against the static library currently results in a `62MB` installation directory (since `libtss.a` is `1.1MB` in size) We should probably cherry-pick the utilities we care about and only install / package those.

PS. Just a reminder that this is a _public_ GitHub repo :information_source: 