### PR TITLE
Add helper script for building Debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Other
+*.deb

--- a/ci_tools/build_debian.sh
+++ b/ci_tools/build_debian.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -eu
+
+VERSION=${1:-"1.0.0-0mayfield0"} # Upstream version: 1045
+SCRIPTDIR=$(dirname "$(readlink -e ${0})")
+REPODIR=${SCRIPTDIR}/..
+INSTALLDIR=$(mktemp -dt tpm2_installdir.XXXXXX)
+
+cd ${REPODIR}/utils
+make
+DESTDIR=${INSTALLDIR} make install
+make clean
+cd ${REPODIR}
+
+fpm \
+  --input-type dir \
+  --chdir ${INSTALLDIR} \
+  --output-type deb \
+  --name "ibm-tpm2-tools" \
+  --architecture native \
+  --version "${VERSION}" \
+  --license "BSD" \
+  --vendor "IBM" \
+  --description "IBM's TPM 2.0 TSS packaged by Mayfield Robotics." \
+  --maintainer "Spyros Maniatopoulos <spyros@mayfieldrobotics.com>" \
+  --url "https://github.com/MayfieldRoboticsPublic/ibmtpm20tss" \
+  .
+
+rm -rf ${INSTALLDIR}


### PR DESCRIPTION
Looking for feedback on versioning and on installation directory :slightly_smiling_face: Result:

```
$ dpkg-deb --info ibm-tpm2-tools_1.0.0-0mayfield0_amd64.deb 

 new debian package, version 2.0.
 size 2792502 bytes: control archive=3493 bytes.
     338 bytes,    11 lines      control              
    7359 bytes,   109 lines      md5sums              
 Package: ibm-tpm2-tools
 Version: 1.0.0-0mayfield0
 License: BSD
 Vendor: IBM
 Architecture: amd64
 Maintainer: Spyros Maniatopoulos <spyros@mayfieldrobotics.com>
 Installed-Size: 6697
 Section: default
 Priority: extra
 Homepage: https://github.com/MayfieldRoboticsPublic/ibmtpm20tss
 Description: IBM's TPM 2.0 TSS packaged by Mayfield Robotics.
```

```
$ dpkg-deb --contents ibm-tpm2-tools_1.0.0-0mayfield0_amd64.deb 

drwx------ 0/0               0 2017-09-05 17:21 ./
drwxr-xr-x 0/0               0 2017-09-05 17:21 ./opt/
drwxr-xr-x 0/0               0 2017-09-05 17:21 ./opt/tpm/
drwxr-xr-x 0/0               0 2017-09-05 17:21 ./opt/tpm/bin/
-rwxr-xr-x 0/0          140021 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_writeapp
-rwxr-xr-x 0/0           39841 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvextend
-rwxr-xr-x 0/0           39794 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_hierarchycontrol
-rwxr-xr-x 0/0           52215 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_getcommandauditdigest
-rwxr-xr-x 0/0           39711 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policynvwritten
-rwxr-xr-x 0/0           16997 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_timepacket
-rwxr-xr-x 0/0           39625 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvglobalwritelock
-rwxr-xr-x 0/0           67921 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_getcapability
-rwxr-xr-x 0/0           39643 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvwritelock
-rwxr-xr-x 0/0           50451 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_objectchangeauth
-rwxr-xr-x 0/0           66121 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_eventextend
-rwxr-xr-x 0/0           52201 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_certify
-rwxr-xr-x 0/0           39655 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvundefinespace
-rwxr-xr-x 0/0           50746 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_import
-rwxr-xr-x 0/0           44077 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policycountertimer
-rwxr-xr-x 0/0           44326 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_hierarchychangeauth
-rwxr-xr-x 0/0           39587 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvincrement
-rwxr-xr-x 0/0           65876 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_imaextend
-rwxr-xr-x 0/0           45872 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_contextsave
-rwxr-xr-x 0/0           39263 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policyauthvalue
-rwxr-xr-x 0/0           39514 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policytemplate
-rwxr-xr-x 0/0           46042 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_hmacstart
-rwxr-xr-x 0/0           39827 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvsetbits
-rwxr-xr-x 0/0           52672 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_certifycreation
lrwxrwxrwx 0/0               0 2017-09-05 17:21 ./opt/tpm/bin/libtss.so -> libtss.so.0
-rwxr-xr-x 0/0           15981 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_powerup
-rwxr-xr-x 0/0           45753 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policygetdigest
-rwxr-xr-x 0/0           44405 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policyticket
-rwxr-xr-x 0/0           39662 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvundefinespacespecial
-rwxr-xr-x 0/0           46040 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_unseal
-rwxr-xr-x 0/0          101645 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_createprimary
-rwxr-xr-x 0/0           39697 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policyauthorizenv
-rwxr-xr-x 0/0           52207 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_quote
-rwxr-xr-x 0/0           39408 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policycphash
-rwxr-xr-x 0/0           39648 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_clockset
-rwxr-xr-x 0/0           50427 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_rewrap
-rwxr-xr-x 0/0           46254 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_load
-rwxr-xr-x 0/0          126555 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_createek
-rwxr-xr-x 0/0           39252 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_flushcontext
-rwxr-xr-x 0/0           39549 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policyrestart
-rwxr-xr-x 0/0           39553 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_changeeps
-rwxr-xr-x 0/0           45778 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_contextload
-rwxr-xr-x 0/0          135267 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvwrite
-rwxr-xr-x 0/0           50781 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_sequencecomplete
-rwxr-xr-x 0/0           46171 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_pcrevent
-rwxr-xr-x 0/0           40037 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policyauthorize
-rwxr-xr-x 0/0           50527 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_eventsequencecomplete
-rwxr-xr-x 0/0           39903 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_sequenceupdate
-rwxr-xr-x 0/0           50697 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_hmac
-rwxr-xr-x 0/0           16067 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_ntc2lockconfig
-rwxr-xr-x 0/0           39686 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_clearcontrol
-rwxr-xr-x 0/0           45963 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_pcrallocate
-rwxr-xr-x 0/0           50430 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_duplicate
-rwxr-xr-x 0/0           50282 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvreadpublic
-rwxr-xr-x 0/0           45994 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_hashsequencestart
-rwxr-xr-x 0/0           10265 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_returncode
-rwxr-xr-x 0/0           39676 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_evictcontrol
-rwxr-xr-x 0/0           39830 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_pcrextend
-rwxr-xr-x 0/0           39712 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policyor
-rwxr-xr-x 0/0           39732 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_dictionaryattackparameters
-rwxr-xr-x 0/0          154194 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_importpem
-rwxr-xr-x 0/0           39313 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policycommandcode
-rwxr-xr-x 0/0           51494 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_rsadecrypt
-rwxr-xr-x 0/0           39173 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_shutdown
-rwxr-xr-x 0/0           46125 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_startauthsession
-rwxr-xr-x 0/0           17670 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policymaker
-rwxr-xr-x 0/0           39703 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_clockrateadjust
-rwxr-xr-x 0/0           39701 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policypcr
-rwxr-xr-x 0/0           39553 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_changepps
-rwxr-xr-x 0/0           52085 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_gettime
-rwxr-xr-x 0/0           46162 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_pcrread
-rwxr-xr-x 0/0           52263 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_getsessionauditdigest
-rwxr-xr-x 0/0           50561 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_makecredential
-rwxr-xr-x 0/0           39464 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_stirrandom
-rwxr-xr-x 0/0           50644 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_hash
-rwxr-xr-x 0/0           50743 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_commit
-rwxr-xr-x 0/0           39749 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvchangeauth
-rwxr-xr-x 0/0           45832 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_ecephemeral
-rwxr-xr-x 0/0           48680 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvdefinespace
-rwxr-xr-x 0/0           39642 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvreadlock
-rwxr-xr-x 0/0          101390 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_create
-rwxr-xr-x 0/0           39589 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_clear
-rwxr-xr-x 0/0           51241 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_ntc2preconfig
-rwxr-xr-x 0/0           39539 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_startup
-rwxr-xr-x 0/0           83624 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_verifysignature
-rwxr-xr-x 0/0           53459 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_sign
-rwxr-xr-x 0/0          101323 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_createloaded
-rwxr-xr-x 0/0           50512 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_getrandom
-rwxr-xr-x 0/0          146595 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_signapp
-rwxr-xr-x 0/0           53773 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policysigned
-rwxr-xr-x 0/0           52155 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvcertify
-rwxr-xr-x 0/0          139520 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_loadexternal
-rwxr-xr-x 0/0           39248 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_pcrreset
-rwxr-xr-x 0/0           83149 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_readpublic
-rwxr-xr-x 0/0          139319 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_nvread
-rwxr-xr-x 0/0           36992 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_ntc2getconfig
-rwxr-xr-x 0/0           39844 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_setprimarypolicy
-rwxr-xr-x 0/0           39262 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policypassword
-rwxr-xr-x 0/0           31975 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_readclock
-rwxr-xr-x 0/0           39601 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_dictionaryattacklockreset
-rwxr-xr-x 0/0           50732 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policysecret
-rwxr-xr-x 0/0           22857 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policymakerpcr
-rwxr-xr-x 0/0          663395 2017-09-05 17:21 ./opt/tpm/bin/libtss.so.0
-rwxr-xr-x 0/0           46319 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_rsaencrypt
-rwxr-xr-x 0/0           51000 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_encryptdecrypt
-rwxr-xr-x 0/0           50625 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_activatecredential
-rwxr-xr-x 0/0           44163 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_policynv
-rwxr-xr-x 0/0          663395 2017-09-05 17:21 ./opt/tpm/bin/libtss.so.0.1
-rwxr-xr-x 0/0           45836 2017-09-05 17:21 ./opt/tpm/bin/ibm_tpm2_eccparameters
drwxr-xr-x 0/0               0 2017-09-05 17:21 ./usr/
drwxr-xr-x 0/0               0 2017-09-05 17:21 ./usr/share/
drwxr-xr-x 0/0               0 2017-09-05 17:21 ./usr/share/doc/
drwxr-xr-x 0/0               0 2017-09-05 17:21 ./usr/share/doc/ibm-tpm2-tools/
-rw-r--r-- 0/0             170 2017-09-05 17:21 ./usr/share/doc/ibm-tpm2-tools/changelog.gz
```